### PR TITLE
:bug: fix: Nome do emoji na tabela de exemplos

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ O commit semântico possui os elementos estruturais abaixo (tipos), que informam
     </tr>
     <tr>
       <td>
-        <code>git commit -m ":bulb: raw: RAW Data do ano aaaa"</code>
+        <code>git commit -m ":card_file_box: raw: RAW Data do ano aaaa"</code>
       </td>
       <td>🗃️ raw: RAW Data do ano aaaa</td>
     </tr>


### PR DESCRIPTION
Corrigindo o nome do emoji presente na ultima linha da tabela de exemplos antes era :"bulb": que é a 💡 sendo que deveria ser :"card_file_box": que é o seguinte emoji 🗃️